### PR TITLE
Add Sync snapshot fix for bootstraping new nodes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       COINBASE: ""
       VALIDATOR_PRIVATE_KEYS: ""
       BLOB_SINK_URL: ""
+      SYNC_SNAPSHOTS_URL: ""
       LOG_LEVEL: "info"
     restart: unless-stopped
 volumes:

--- a/package_variants/sepolia/docker-compose.yml
+++ b/package_variants/sepolia/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       ETHEREUM_HOSTS: http://geth.sepolia-geth.dappnode:8545
       L1_CONSENSUS_HOST_URLS: http://prysm-sepolia.dappnode:3500
+      SYNC_SNAPSHOTS_URL: https://aztec.denodes.xyz/snapshot/
     ports:
       - 40400:40400/tcp
       - 40400:40400/udp

--- a/sequencer/Dockerfile
+++ b/sequencer/Dockerfile
@@ -13,4 +13,6 @@ ENV NETWORK=${NETWORK} \
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+RUN apt-get update && apt-get install -y lz4 wget
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/sequencer/entrypoint.sh
+++ b/sequencer/entrypoint.sh
@@ -13,11 +13,27 @@ set -euo pipefail
 P2P_IP="${_DAPPNODE_GLOBAL_PUBLIC_IP}" # aztec expects P2P_IP to be set, but dappmanager injects the env as `_DAPPNODE_GLOBAL_PUBLIC_IP`
 export P2P_IP
 
+SYNC_SNAPSHOTS_URL=https://aztec.denodes.xyz/snapshot/
+export SYNC_SNAPSHOTS_URL
+
 # — Build the command array
 FLAGS=(
   start
   --network "$NETWORK"
 )
+
+# — Create target directory and download snapshot only if empty
+# mkdir -p /root/.aztec/alpha-testnet
+if [ -z "$(ls -A /data/aztec-alpha-testnet.tar.lz4)" ]; then
+    echo "[INFO - entrypoint] Target folder is empty, downloading snapshot..."
+    wget https://files5.blacknodes.net/aztec/aztec-alpha-testnet.tar.lz4 -O /data/aztec-alpha-testnet.tar.lz4
+    lz4 -d /data/aztec-alpha-testnet.tar.lz4 /data/aztec-alpha-testnet.tar
+    tar -xvf /data/aztec-alpha-testnet.tar -C /
+    rm /data/aztec-alpha-testnet.tar.lz4 /data/aztec-alpha-testnet.tar
+    echo "[INFO - entrypoint] Snapshot download and extraction completed"
+else
+    echo "[INFO - entrypoint] Target folder is not empty, skipping snapshot download"
+fi
 
 # — Append fixed mode flags
 FLAGS+=(--archiver --node --sequencer)

--- a/sequencer/entrypoint.sh
+++ b/sequencer/entrypoint.sh
@@ -13,23 +13,19 @@ set -euo pipefail
 P2P_IP="${_DAPPNODE_GLOBAL_PUBLIC_IP}" # aztec expects P2P_IP to be set, but dappmanager injects the env as `_DAPPNODE_GLOBAL_PUBLIC_IP`
 export P2P_IP
 
-SYNC_SNAPSHOTS_URL=https://aztec.denodes.xyz/snapshot/
-export SYNC_SNAPSHOTS_URL
-
 # — Build the command array
 FLAGS=(
   start
   --network "$NETWORK"
 )
 
-# — Create target directory and download snapshot only if empty
-# mkdir -p /root/.aztec/alpha-testnet
+# — Download snapshot only if empty
 if [ -z "$(ls -A /data/aztec-alpha-testnet.tar.lz4)" ]; then
     echo "[INFO - entrypoint] Target folder is empty, downloading snapshot..."
     wget https://files5.blacknodes.net/aztec/aztec-alpha-testnet.tar.lz4 -O /data/aztec-alpha-testnet.tar.lz4
     lz4 -d /data/aztec-alpha-testnet.tar.lz4 /data/aztec-alpha-testnet.tar
     tar -xvf /data/aztec-alpha-testnet.tar -C /
-    rm /data/aztec-alpha-testnet.tar.lz4 /data/aztec-alpha-testnet.tar
+    rm /data/aztec-alpha-testnet.tar
     echo "[INFO - entrypoint] Snapshot download and extraction completed"
 else
     echo "[INFO - entrypoint] Target folder is not empty, skipping snapshot download"


### PR DESCRIPTION
This PR fixes the issue when a new Aztec node is trying to sync:

- Add SYNC_SNAPSHOTS_URL env variable with official snapshot URL. However, this is currently not working, as mentioned in this [Discord thread](https://discord.com/channels/1144692727120937080/1366895862042722395/1413794378333294634)
- Update Dockerfile: installs `lz4` and `wget`
- Update `entrypoint.sh`: manually downloads (as recommended in the above Discord thread) and extracts the snapshot data to the `/data` folder (only if it's the first time the node starts)